### PR TITLE
Put mex file in correct location

### DIFF
--- a/mmc.spec
+++ b/mmc.spec
@@ -173,8 +173,8 @@ install -m 0755 -pd %{buildroot}%{_bindir}
 install -m 0755 -pt %{buildroot}%{_bindir} bin/%{name}
 
 # Move mex to arch specific directory
-mkdir -p -m 0755 %{buildroot}/%{octpkglibdir}
-mv %{buildroot}/%{octpkgdir}/*.mex %{buildroot}/%{octpkglibdir}/ -v
+mkdir -p -m 0755 %{buildroot}/%{octpkglibdir}/%{octave_host}-%{octave_api}
+mv %{buildroot}/%{octpkgdir}/*.mex %{buildroot}/%{octpkglibdir}/%{octave_host}-%{octave_api} -v
 
 %post -n octave-%{octpkg}
 %octave_cmd pkg rebuild


### PR DESCRIPTION
This fixes it. Now, it works fine:

```
(ins)>> pkg list
Package Name  | Version | Installation directory
--------------+---------+-----------------------
    iso2mesh  |   1.9.1 | /usr/share/octave/packages/iso2mesh-1.9.1
      jnifti  |     0.5 | /usr/share/octave/packages/jnifti-0.5
     jsonlab  |   1.9.8 | /usr/share/octave/packages/jsonlab-1.9.8
      mmclab  |   1.7.9 | /usr/share/octave/packages/mmclab-1.7.9
        zmat  |     0.9 | /usr/share/octave/packages/zmat-0.9
(ins)>> pkg load mmclab
(ins)>> mmc
Usage:
    [flux,detphoton]=mmclab(cfg);

Please run 'help mmclab' for more details.
(ins)>> mmclab('gpuinfo')
Platform [0] Name Clover
error: mmc: no active GPU device found
error: called from
    mmclab at line 265 column 17
(ins)>> which mmc
'mmc' is a function from the file /usr/lib64/octave/packages/mmclab-1.7.9/x86_64-redhat-linux-gnu-api-v53/mmc.mex
(ins)>>
```